### PR TITLE
Fixed bug so that context.xml.template gets copied into the container.

### DIFF
--- a/7-jre7.Dockerfile
+++ b/7-jre7.Dockerfile
@@ -4,8 +4,7 @@ FROM tomcat:7-jre7
 COPY docker/manager.xml conf/Catalina/localhost/
 
 # Copy configuration and run scripts
-COPY docker/run.sh bin/
-COPY docker/*.p[lm] /usr/local/bin/
+COPY ["docker/*.p[lm]", "docker/*.template", "docker/run.sh", "/usr/local/bin/"]
 
 CMD ["run.sh"]
 

--- a/7-jre8.Dockerfile
+++ b/7-jre8.Dockerfile
@@ -4,8 +4,7 @@ FROM tomcat:7-jre8
 COPY docker/manager.xml conf/Catalina/localhost/
 
 # Copy configuration and run scripts
-COPY docker/run.sh bin/
-COPY docker/*.p[lm] /usr/local/bin/
+COPY ["docker/*.p[lm]", "docker/*.template", "docker/run.sh", "/usr/local/bin/"]
 
 CMD ["run.sh"]
 

--- a/8-jre7.Dockerfile
+++ b/8-jre7.Dockerfile
@@ -4,8 +4,7 @@ FROM tomcat:8-jre7
 COPY docker/manager.xml conf/Catalina/localhost/
 
 # Copy configuration and run scripts
-COPY docker/run.sh bin/
-COPY docker/*.p[lm] /usr/local/bin/
+COPY ["docker/*.p[lm]", "docker/*.template", "docker/run.sh", "/usr/local/bin/"]
 
 CMD ["run.sh"]
 

--- a/8-jre8.Dockerfile
+++ b/8-jre8.Dockerfile
@@ -4,8 +4,7 @@ FROM tomcat:8-jre8
 COPY docker/manager.xml conf/Catalina/localhost/
 
 # Copy configuration and run scripts
-COPY docker/run.sh bin/
-COPY docker/*.p[lm] /usr/local/bin/
+COPY ["docker/*.p[lm]", "docker/*.template", "docker/run.sh", "/usr/local/bin/"]
 
 CMD ["run.sh"]
 


### PR DESCRIPTION
context.xml.template was not being copied into the container and there was a file not found error when running derived containers.