### PR TITLE
Copy app files from a subdirectory

### DIFF
--- a/7-jre7-alpine.Dockerfile
+++ b/7-jre7-alpine.Dockerfile
@@ -14,7 +14,7 @@ CMD ["run.sh"]
 
 # Copy JARs and WARs
 ONBUILD COPY lib/*.jar lib/
-ONBUILD ADD *.war webapps/
+ONBUILD ADD  app/*.war webapps/
 
 # Allow root group to read all files
 ONBUILD RUN chgrp -R 0 /usr/local/tomcat && \

--- a/7-jre7.Dockerfile
+++ b/7-jre7.Dockerfile
@@ -10,7 +10,7 @@ CMD ["run.sh"]
 
 # Copy JARs and WARs
 ONBUILD COPY lib/*.jar lib/
-ONBUILD ADD *.war webapps/
+ONBUILD ADD  app/*.war webapps/
 
 # Allow root group to read all files
 ONBUILD RUN chgrp -R 0 /usr/local/tomcat && \

--- a/7-jre8-alpine.Dockerfile
+++ b/7-jre8-alpine.Dockerfile
@@ -14,7 +14,7 @@ CMD ["run.sh"]
 
 # Copy JARs and WARs
 ONBUILD COPY lib/*.jar lib/
-ONBUILD ADD *.war webapps/
+ONBUILD ADD  app/*.war webapps/
 
 # Allow root group to read all files
 ONBUILD RUN chgrp -R 0 /usr/local/tomcat && \

--- a/7-jre8.Dockerfile
+++ b/7-jre8.Dockerfile
@@ -10,7 +10,7 @@ CMD ["run.sh"]
 
 # Copy JARs and WARs
 ONBUILD COPY lib/*.jar lib/
-ONBUILD ADD *.war webapps/
+ONBUILD ADD  app/*.war webapps/
 
 # Allow root group to read all files
 ONBUILD RUN chgrp -R 0 /usr/local/tomcat && \

--- a/8-jre7.Dockerfile
+++ b/8-jre7.Dockerfile
@@ -10,7 +10,7 @@ CMD ["run.sh"]
 
 # Copy JARs and WARs
 ONBUILD COPY lib/*.jar lib/
-ONBUILD ADD *.war webapps/
+ONBUILD ADD  app/*.war webapps/
 
 # Allow root group to read all files
 ONBUILD RUN chgrp -R 0 /usr/local/tomcat && \

--- a/8-jre8-alpine.Dockerfile
+++ b/8-jre8-alpine.Dockerfile
@@ -14,7 +14,7 @@ CMD ["run.sh"]
 
 # Copy JARs and WARs
 ONBUILD COPY lib/*.jar lib/
-ONBUILD ADD *.war webapps/
+ONBUILD ADD  app/*.war webapps/
 
 # Allow root group to read all files
 ONBUILD RUN chgrp -R 0 /usr/local/tomcat && \

--- a/8-jre8.Dockerfile
+++ b/8-jre8.Dockerfile
@@ -10,7 +10,7 @@ CMD ["run.sh"]
 
 # Copy JARs and WARs
 ONBUILD COPY lib/*.jar lib/
-ONBUILD ADD *.war webapps/
+ONBUILD ADD  app/*.war webapps/
 
 # Allow root group to read all files
 ONBUILD RUN chgrp -R 0 /usr/local/tomcat && \


### PR DESCRIPTION
- This change was made due to a refactor of product repos to tidy everything up
- All phase one apps support this file structure