### PR TITLE
Update deprecated and ignored context attributes

### DIFF
--- a/docker/TomcatContextUtil.pm
+++ b/docker/TomcatContextUtil.pm
@@ -285,9 +285,9 @@ sub get_resource {
         driverclass => $driverclasses{$driver},
         validation => $validations{$driver},
 
-        maxactive => $read_resource->($ref, 'MAXACTIVE', '10'),
+        maxtotal => $read_resource->($ref, 'MAXACTIVE', '10'),
         maxidle => $read_resource->($ref, 'MAXIDLE', '2'),
-        maxwait => $read_resource->($ref, 'MAXWAIT', '2000'),
+        maxwaitmillis => $read_resource->($ref, 'MAXWAIT', '2000'),
         pass => $password
     }
 }

--- a/docker/context.xml.template
+++ b/docker/context.xml.template
@@ -4,9 +4,9 @@
         $OUT .= "    <Resource name=\"jdbc/$r->{'resource'}\"\n";
         $OUT .= "        auth=\"Container\"\n";
         $OUT .= "        type=\"javax.sql.DataSource\"\n";
-        $OUT .= "        maxActive=\"$r->{'maxactive'}\"\n";
+        $OUT .= "        maxTotal=\"$r->{'maxtotal'}\"\n";
         $OUT .= "        maxIdle=\"$r->{'maxidle'}\"\n";
-        $OUT .= "        maxWait=\"$r->{'maxwait'}\"\n";
+        $OUT .= "        maxWaitMillis=\"$r->{'maxwaitmillis'}\"\n";
         $OUT .= "        username=\"$r->{'user'}\"\n";
         $OUT .= "        password=\"$r->{'pass'}\"\n";
         $OUT .= "        driverClassName=\"$r->{'driverclass'}\"\n";


### PR DESCRIPTION
- Tomcat was logging warnings that 'maxwait' and 'maxactive' had been
renamed to 'maxwaitmillis' and 'maxtotal'
- Since the old spelling was deprecated they were being ignored
- Renaming them makes Tomcat actually honour them again
- I have not renamed the source environment variables because that would
mean that every dependant project would have to be updated